### PR TITLE
Bump NEURON to v8.0.0 + patched external/iv/src/lib/CMakeLists.txt

### DIFF
--- a/recipe/TIFF_DEFINES.patch
+++ b/recipe/TIFF_DEFINES.patch
@@ -1,0 +1,24 @@
+From 5cb5f8a5ebf30fca4d10fca323725b4bcc096209 Mon Sep 17 00:00:00 2001
+From: Espen Hagen <2492641+espenhgn@users.noreply.github.com>
+Date: Wed, 5 May 2021 10:57:03 +0200
+Subject: [PATCH] osx-arm64 nonfix
+
+---
+ external//src/lib/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/external/iv/src/lib/CMakeLists.txt b/external/iv/src/lib/CMakeLists.txt
+index b783083..5725bcf 100644
+--- a/external/iv/src/lib/CMakeLists.txt
++++ b/external/iv/src/lib/CMakeLists.txt
+@@ -347,7 +347,7 @@ set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TIFF/tif_fax3.c
+ set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TIFF/mkg3states.c
+                             PROPERTIES
+                             COMPILE_FLAGS
+-                            ${TIFF_DEFINES})
++                            "-arch x86_64 ${TIFF_DEFINES}")
+
+ add_executable(mkg3states ${CMAKE_CURRENT_SOURCE_DIR}/TIFF/mkg3states.c)
+ target_include_directories(mkg3states PUBLIC ${IV_PROJECT_SOURCE_DIR}/src/include/TIFF)
+--
+2.30.2

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,8 +39,7 @@ cmake $CMAKE_ARGS \
   -DNRN_MODULE_INSTALL_OPTIONS= \
   ..
 
-make -j ${CPU_COUNT:-1}
-make install
+cmake --build . --parallel ${CPU_COUNT:-1} --target install
 
 # remove some built files that shouldn't be installed
 if [[ "${target_platform}" == *-64 ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "7.8.2" %}
+{% set version = "8.0.0" %}
 {% set xy = version.rsplit('.', 1)[0] %}
-{% set build = 3 %}
+{% set build = 0 %}
 
 {% if not mpi %}
 # conda-smithy misbehaves if mpi is unset
@@ -18,7 +18,7 @@ package:
 
 source:
   - url: https://github.com/neuronsimulator/nrn/releases/download/{{ version }}/full-src-package-{{ version }}.tar.gz
-    sha256: 7ab615b36370220d5048214463414bc54245489c14c79899d86e7bb6d3549edf
+    sha256: 46f5bea1a5a9c7e0b7dcc74216b3f74602220f5efee1a6d0d2c9b185e61b3873
     patches:
       - avoid-basename-s.patch  # [linux]
       - x-sentinel.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ source:
     patches:
       - avoid-basename-s.patch  # [linux]
       - x-sentinel.patch
+      - TIFF_DEFINES.patch  # [target_platform == 'osx-arm64']
 
 build:
   number: {{ build }}


### PR DESCRIPTION
I see some printed output "Patch level ambiguous, selecting least deep" when applying the patch during build using `conda build recipe ...`. Not sure how to avoid that.

`nompi` builds results in undefined identifiers; `mpimpich/mpiopenmpi` builds still won't find `MPI_CXX`, so ultimately this PR doesn't yet fix anything. 

@isuruf, do you have any further suggestions to try?